### PR TITLE
Don't build on java <17

### DIFF
--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -11,13 +11,7 @@ jobs:
     strategy:
       matrix:
         # Use these Java versions
-        java: [
-            1.8,
-            11,
-            15,
-            16,
-            17
-        ]
+        java: [17]
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
1.18 won't run on it anyways, so why build for it?