### PR TITLE
Update for Minecraft 1.19

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         run: chmod +x ./gradlew
       - name: Build
-        run: ./gradlew generateChangelog build publish curseforge github publishModrinth --stacktrace --parallel -PlastTag="v${{ github.event.inputs.previousVersion }}" -PcurrentTag="v${{ github.event.inputs.version }}"
+        run: ./gradlew generateChangelog build publish curseforge github modrinth --stacktrace --parallel -PlastTag="v${{ github.event.inputs.previousVersion }}" -PcurrentTag="v${{ github.event.inputs.version }}"
         env:
           MAVEN_URL: ${{ secrets.MAVEN_URL }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.10-SNAPSHOT'
+	id 'fabric-loom' version '0.12-SNAPSHOT'
 }
 
 apply from: 'https://raw.githubusercontent.com/TerraformersMC/GradleScripts/2.1/ferry.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'fabric-loom' version '0.12-SNAPSHOT'
 }
 
-apply from: 'https://raw.githubusercontent.com/TerraformersMC/GradleScripts/2.1/ferry.gradle'
+apply from: 'https://raw.githubusercontent.com/TerraformersMC/GradleScripts/2.5/ferry.gradle'
 
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@ org.gradle.jvmargs=-Xmx1G
 maven_group=com.terraformersmc
 archive_name=vistas
 
-minecraft_version=1.19
-yarn_mappings=1.19+build.4
-loader_version=0.14.8
-fabric_version=0.56.0+1.19
-modmenu_version=4.0.0
-clothconfig_version=7.0.65
+minecraft_version=1.19.2
+yarn_mappings=1.19.2+build.3
+loader_version=0.14.9
+fabric_version=0.59.0+1.19.2
+modmenu_version=4.0.6
+clothconfig_version=8.0.75
 
 # Project Metadata
 project_name=Vistas
@@ -21,14 +21,14 @@ default_release_type=beta
 # CurseForge Metadata
 curseforge_slug=vistas
 curseforge_id=423659
-curseforge_game_versions=1.18, Fabric
+curseforge_game_versions=1.19, 1.19.1, 1.19.2, Fabric
 curseforge_required_dependencies=
 curseforge_optional_dependencies=
 
 # Modrinth Metadata
 modrinth_slug=vistas
 modrinth_id=itzZXRxq
-modrinth_game_versions=1.18
+modrinth_game_versions=1.19, 1.19.1, 1.19.2
 modrinth_mod_loaders=fabric
 
 # Mod Loader Metadata

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@ org.gradle.jvmargs=-Xmx1G
 maven_group=com.terraformersmc
 archive_name=vistas
 
-minecraft_version=1.18.2
-yarn_mappings=1.18.2+build.2
-loader_version=0.13.3
-fabric_version=0.48.0+1.18.2
-modmenu_version=3.0.0
-clothconfig_version=6.0.42
+minecraft_version=1.19-rc2
+yarn_mappings=1.19-rc2+build.1
+loader_version=0.14.6
+fabric_version=0.55.1+1.19
+modmenu_version=3.2.2
+clothconfig_version=7.0.65
 
 # Project Metadata
 project_name=Vistas

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ archive_name=vistas
 
 minecraft_version=1.19
 yarn_mappings=1.19+build.4
-loader_version=0.14.7
+loader_version=0.14.8
 fabric_version=0.56.0+1.19
 modmenu_version=4.0.0
 clothconfig_version=7.0.65

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,11 +3,11 @@ org.gradle.jvmargs=-Xmx1G
 maven_group=com.terraformersmc
 archive_name=vistas
 
-minecraft_version=1.19-rc2
-yarn_mappings=1.19-rc2+build.1
-loader_version=0.14.6
-fabric_version=0.55.1+1.19
-modmenu_version=3.2.2
+minecraft_version=1.19
+yarn_mappings=1.19+build.4
+loader_version=0.14.7
+fabric_version=0.56.0+1.19
+modmenu_version=4.0.0
 clothconfig_version=7.0.65
 
 # Project Metadata

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ org.gradle.jvmargs=-Xmx1G
 maven_group=com.terraformersmc
 archive_name=vistas
 
-minecraft_version=1.18
-yarn_mappings=1.18+build.1
-loader_version=0.12.6
-fabric_version=0.43.1+1.18
+minecraft_version=1.18.2
+yarn_mappings=1.18.2+build.2
+loader_version=0.13.3
+fabric_version=0.48.0+1.18.2
 modmenu_version=3.0.0
 clothconfig_version=6.0.42
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/terraformersmc/vistas/mixin/GameRendererMixin.java
+++ b/src/main/java/com/terraformersmc/vistas/mixin/GameRendererMixin.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Optional;
 
+import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -34,8 +35,6 @@ import net.minecraft.client.texture.NativeImage;
 import net.minecraft.client.util.ScreenshotRecorder;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.ClickEvent;
-import net.minecraft.text.LiteralText;
-import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Util;
 import net.minecraft.util.math.Direction;
@@ -69,7 +68,7 @@ public abstract class GameRendererMixin {
 				client.player.setYaw(PanoramicScreenshots.startingRotation.get().getSecond());
 			}
 			if (client.player != null) {
-				client.player.sendMessage(new TranslatableText("vistas.panoramic_screenshot.broke"), false);
+				client.player.sendMessage(Text.translatable("vistas.panoramic_screenshot.broke"), false);
 			}
 			PanoramicScreenshots.onShot = -1;
 			PanoramicScreenshots.startingRotation = Optional.empty();
@@ -126,7 +125,7 @@ public abstract class GameRendererMixin {
 			framebuffer.delete();
 
 			if (client.player != null && VistasConfig.getInstance().screenshotIndividually) {
-				client.player.sendMessage(new TranslatableText("vistas.panoramic_screenshot.taken", new LiteralText(String.valueOf(PanoramicScreenshots.onShot)), new LiteralText(file.getName()).formatted(Formatting.UNDERLINE).styled((style) -> style.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_FILE, file.getAbsolutePath())))), false);
+				client.player.sendMessage(Text.translatable("vistas.panoramic_screenshot.taken", Text.literal(String.valueOf(PanoramicScreenshots.onShot)), Text.literal(file.getName()).formatted(Formatting.UNDERLINE).styled((style) -> style.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_FILE, file.getAbsolutePath())))), false);
 			}
 
 			if (PanoramicScreenshots.onShot == 5) {
@@ -138,7 +137,7 @@ public abstract class GameRendererMixin {
 				PanoramicScreenshots.time = 0.0D;
 				PanoramicScreenshots.timeSinceLastKeyPress = 10.0D;
 				if (client.player != null) {
-					client.player.sendMessage(new TranslatableText("vistas.panoramic_screenshot.saved", new LiteralText(root.toAbsolutePath().toString()).styled(style -> style.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_FILE, root.toAbsolutePath().toString())).withUnderline(true))), false);
+					client.player.sendMessage(Text.translatable("vistas.panoramic_screenshot.saved", Text.literal(root.toAbsolutePath().toString()).styled(style -> style.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_FILE, root.toAbsolutePath().toString())).withUnderline(true))), false);
 				}
 			} else {
 				// push

--- a/src/main/java/com/terraformersmc/vistas/mixin/MinecraftClientMixin.java
+++ b/src/main/java/com/terraformersmc/vistas/mixin/MinecraftClientMixin.java
@@ -20,7 +20,7 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.RunArgs;
 import net.minecraft.client.network.ClientPlayerEntity;
-import net.minecraft.resource.ReloadableResourceManager;
+import net.minecraft.resource.ReloadableResourceManagerImpl;
 import net.minecraft.sound.MusicSound;
 
 @Environment(EnvType.CLIENT)
@@ -32,13 +32,13 @@ public class MinecraftClientMixin implements MinecraftClientAccess {
 
 	@Shadow
 	@Final
-	private ReloadableResourceManager resourceManager;
+	private ReloadableResourceManagerImpl resourceManager;
 
 	@Nullable
 	@Shadow
 	public ClientPlayerEntity player;
 
-	@Inject(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/resource/ReloadableResourceManager;registerReloader(Lnet/minecraft/resource/ResourceReloader;)V", ordinal = 2, shift = Shift.AFTER))
+	@Inject(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/resource/ReloadableResourceManagerImpl;registerReloader(Lnet/minecraft/resource/ResourceReloader;)V", ordinal = 2, shift = Shift.AFTER))
 	private void vistas$init$registerPanoramaReloader(RunArgs args, CallbackInfo ci) {
 		this.panoramaResourceReloader = new PanoramaResourceReloader();
 		this.resourceManager.registerReloader(panoramaResourceReloader);

--- a/src/main/java/com/terraformersmc/vistas/mixin/SplashTextResourceSupplierMixin.java
+++ b/src/main/java/com/terraformersmc/vistas/mixin/SplashTextResourceSupplierMixin.java
@@ -1,5 +1,7 @@
 package com.terraformersmc.vistas.mixin;
 
+import com.terraformersmc.vistas.title.VistasTitle;
+import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -30,7 +32,9 @@ public class SplashTextResourceSupplierMixin {
 	private void vistas$get(CallbackInfoReturnable<String> ci) {
 		MinecraftClient client = MinecraftClient.getInstance();
 		PanoramaResourceReloader resourceReloader = ((MinecraftClientAccess) client).getPanoramaResourceReloader();
-		if (resourceReloader != null) {
+		Identifier panoramaId = VistasTitle.PANORAMAS_INVERT.get(VistasTitle.CURRENT.getValue());
+
+		if (resourceReloader != null && panoramaId != null) {
 			ci.setReturnValue(resourceReloader.get());
 		}
 	}

--- a/src/main/java/com/terraformersmc/vistas/mixin/TitleScreenMixin.java
+++ b/src/main/java/com/terraformersmc/vistas/mixin/TitleScreenMixin.java
@@ -85,7 +85,7 @@ public abstract class TitleScreenMixin extends Screen {
 			PanoramaRenderer panoramaRenderer = new PanoramaRenderer(cubemap);
 			panoramaRenderer.render(delta, MathHelper.clamp(f, 0.0F, 1.0F));
 			Identifier overlayId = new Identifier(panoramaRenderer.getCubemap().getCubemapId() + "_overlay.png");
-			if (this.client.getResourceManager().containsResource(overlayId)) {
+			if (this.client.getResourceManager().getResource(overlayId).isPresent()) {
 				RenderSystem.setShader(GameRenderer::getPositionTexShader);
 				RenderSystem.setShaderTexture(0, overlayId);
 				RenderSystem.enableBlend();

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,7 +29,7 @@
 		"vistas.mixins.json"
 	],
 	"depends": {
-		"fabricloader": ">=0.11.3",
+		"fabricloader": ">=0.12.12",
 		"fabric": "*"
 	}
 }

--- a/src/main/resources/vistas.mixins.json
+++ b/src/main/resources/vistas.mixins.json
@@ -2,7 +2,7 @@
 	"required": true,
 	"minVersion": "0.8",
 	"package": "com.terraformersmc.vistas.mixin",
-	"compatibilityLevel": "JAVA_16",
+	"compatibilityLevel": "JAVA_17",
 	"client": [
 		"GameRendererMixin",
 		"MinecraftClientMixin",


### PR DESCRIPTION
This update is a little beefier than the 1.18.2 update was.  I had to remove some (no longer relevant?) error handling from `PanoramaResourceReloader`, which could use a quick review.  However, it has worked fine in my limited testing.