### PR TITLE
Fix a couple minor bugs in Vistas for recent Minecraft.

### DIFF
--- a/src/main/java/com/terraformersmc/vistas/mixin/TitleScreenMixin.java
+++ b/src/main/java/com/terraformersmc/vistas/mixin/TitleScreenMixin.java
@@ -3,6 +3,7 @@ package com.terraformersmc.vistas.mixin;
 import java.util.Random;
 import java.util.function.BiConsumer;
 
+import com.terraformersmc.vistas.resource.PanoramaResourceReloader;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -63,17 +64,19 @@ public abstract class TitleScreenMixin extends Screen {
 		super(title);
 	}
 
-	@Inject(method = "Lnet/minecraft/client/gui/screen/TitleScreen;<init>(Z)V", at = @At("TAIL"))
+	@Inject(method = "<init>(Z)V", at = @At("TAIL"))
 	private void vistas$init(boolean doBackgroundFade, CallbackInfo ci) {
 		this.backgroundRenderer = new BenignCubemapRenderer();
-		this.isVistas = new Random().nextDouble() < 1.0E-4D && VistasTitle.PANORAMAS_INVERT.get(VistasTitle.CURRENT.getValue()).equals(Vistas.DEFAULT);
+		this.isVistas = new Random().nextDouble() < 1.0E-4D && VistasTitle.CURRENT.getValue().equals(VistasTitle.PANORAMAS.get(Vistas.DEFAULT));
 	}
 
 	@Inject(method = "init", at = @At("HEAD"))
 	private void vistas$init(CallbackInfo ci) {
-		VistasTitle.choose();
+		if (PanoramaResourceReloader.isReady()) {
+			VistasTitle.choose();
+		}
 		if (!VistasConfig.getInstance().forcePanorama && VistasConfig.getInstance().randomPerScreen) {
-			this.isVistas = new Random().nextDouble() < 1.0E-4D && VistasTitle.PANORAMAS_INVERT.get(VistasTitle.CURRENT.getValue()).equals(Vistas.DEFAULT);
+			this.isVistas = new Random().nextDouble() < 1.0E-4D && VistasTitle.CURRENT.getValue().equals(VistasTitle.PANORAMAS.get(Vistas.DEFAULT));
 			this.splashText = null;
 		}
 	}

--- a/src/main/java/com/terraformersmc/vistas/resource/PanoramaResourceReloader.java
+++ b/src/main/java/com/terraformersmc/vistas/resource/PanoramaResourceReloader.java
@@ -20,6 +20,7 @@ import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Decoder;
 import com.mojang.serialization.JsonOps;
 import com.terraformersmc.vistas.Vistas;
+import com.terraformersmc.vistas.config.VistasConfig;
 import com.terraformersmc.vistas.panorama.Panorama;
 import com.terraformersmc.vistas.title.VistasTitle;
 
@@ -37,6 +38,12 @@ public class PanoramaResourceReloader extends SinglePreparationResourceReloader<
 	private final ConcurrentMap<Identifier, Pair<List<String>, List<Identifier>>> web = Maps.newConcurrentMap();
 	private final ConcurrentMap<Identifier, Pair<List<String>, List<Identifier>>> parsedSplashWeb = Maps.newConcurrentMap();
 	private final ConcurrentMap<Identifier, List<String>> splashTexts = Maps.newConcurrentMap();
+
+	private static boolean ready = false;
+
+	public static boolean isReady() {
+		return ready;
+	}
 
 	@Override
 	protected HashMap<Identifier, Pair<Panorama, List<String>>> prepare(ResourceManager manager, Profiler profiler) {
@@ -204,6 +211,7 @@ public class PanoramaResourceReloader extends SinglePreparationResourceReloader<
 	@Override
 	protected void apply(HashMap<Identifier, Pair<Panorama, List<String>>> prepared, ResourceManager manager, Profiler profiler) {
 		profiler.startTick();
+		ready = false;
 
 		profiler.push("clear");
 		VistasTitle.clear();
@@ -224,8 +232,16 @@ public class PanoramaResourceReloader extends SinglePreparationResourceReloader<
 
 		profiler.pop();
 
-		VistasTitle.choose(profiler);
+		if (VistasConfig.getInstance().randomPerScreen || VistasConfig.getInstance().forcePanorama) {
+			VistasTitle.choose(profiler);
+		} else {
+			// We need to set a random panorama once at start-up and this is a decent proxy for that.
+			profiler.push("initialize");
+			VistasTitle.CURRENT.setValue(VistasTitle.getRandom());
+			profiler.pop();
+		}
 
+		ready = true;
 		profiler.endTick();
 	}
 


### PR DESCRIPTION
- Always select a Vista for the initial title screen.
- Don't crash when displaying the Vistas title.